### PR TITLE
Implement a way of saving the raw data from beam profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,11 @@ These 2 modules may be packaged into seperate packages should someone find the t
 Both of these modules inherit the `Camera` class, which guarantees the existence of the following:
 ```python
 x, y, both = cam.AXES.X, cam.AXES.Y, cam.AXES.BOTH  # Enum for the different axes
-cam.getAxis_avg_D4Sigma(axis = x, numsamples = 20)  # Obtains an average D4Sigma diameter
 cam.wait_stable()                                   # Function returns when beam-profiler is stable
 cam.log()
+# To obtain an average D4Sigma diameter
+cam.getAxis_avg_D4Sigma(axis = x, numsamples = 20, returnRaw = False)
+# If returnRaw is set to True, function returns: (data, rawdata)
 ```
 See the specific source code for more detailed documentation of the functions.
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ For every one of these modules described below, the `LoggerMixIn` class has been
 
 Include [`helpers.py`](./src/nanosquared/common/helpers.py) for the `LoggerMixIn` class. See [below](#logging) for more information.
 
+We recommend initializing all modules with the `with` keyword in Python to ensure that the `__exit__()` method is called when the program ends. 
+
 ### Beam-Profilers
 You may use the `NanoScan` and `WinCamD` modules independent of the rest of the code in the repository to manage and use the respective beam-profilers (here loosely referred to as cameras). For that, follow the instructions detailed in the above sections ([NanoScan](#NanoScan) and [WinCamD](#WinCamD)) to install the necessary support software. Then follow the instructions under [Usage](#Usage) to import the necessary packages:
 ```python

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="nanosquared",
-    version="0.4.1",
+    version="0.4.2",
     author="Yudong Sun",
     author_email="yudong.sun@mpq.mpg.de",
     description="Automated M-Squared Measurement",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="nanosquared",
-    version="0.4",
+    version="0.4.1",
     author="Yudong Sun",
     author_email="yudong.sun@mpq.mpg.de",
     description="Automated M-Squared Measurement",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="nanosquared",
-    version="0.4.2",
+    version="0.4.3",
     author="Yudong Sun",
     author_email="yudong.sun@mpq.mpg.de",
     description="Automated M-Squared Measurement",

--- a/src/cli-app/m2-app.py
+++ b/src/cli-app/m2-app.py
@@ -179,7 +179,12 @@ with cam(devMode = devMode) as n:
                             other      = input(CLI.GAP + "Other metadata (e.g. Lens) > ")
 
                             if useNanoScan:
-                                print(f"{CLI.COLORS.HEADER}Obtained:\n--- Wavelength     : {wavelength} nm\n--- Precision      : {precision} pps\n--- Rotation Rate  : {scanrate} Hz\n--- Save Raw Data  : {saveRaw}\n--- Other Metadata : {other}{CLI.COLORS.ENDC}")
+                                print(f"{CLI.COLORS.HEADER}Obtained:\n--- Wavelength     : {wavelength} nm\n--- Precision      : {precision} pps\n--- Rotation Rate  : {scanrate} Hz\n--- Save Raw Data  : {saveRaw}\n--- Post Processing: Mode {removeOutliers}")
+
+                                if removeOutliers == 2:
+                                    print(f"--- Threshold      : {threshold}")
+
+                                print(f"--- Other Metadata : {other}{CLI.COLORS.ENDC}")
                             else:
                                 print(f"{CLI.COLORS.HEADER}Obtained:\n--- Wavelength     : {wavelength} nm\n--- Precision      : {precision} pps\n--- Save Raw Data  : {saveRaw}\n--- Other Metadata : {other}{CLI.COLORS.ENDC}")
 

--- a/src/cli-app/m2-app.py
+++ b/src/cli-app/m2-app.py
@@ -174,12 +174,14 @@ with cam(devMode = devMode) as n:
                                 removeOutliers = 0
                                 threshold = 0.2
 
+                            saveRaw    = CLI.whats_it_gonna_be_boy("Save Raw Data?", default = "no")
+
                             other      = input(CLI.GAP + "Other metadata (e.g. Lens) > ")
 
                             if useNanoScan:
-                                print(f"{CLI.COLORS.HEADER}Obtained:\n--- Wavelength     : {wavelength} nm\n--- Precision      : {precision} pps\n--- Rotation Rate  : {scanrate} Hz\n--- Other Metadata : {other}{CLI.COLORS.ENDC}")
+                                print(f"{CLI.COLORS.HEADER}Obtained:\n--- Wavelength     : {wavelength} nm\n--- Precision      : {precision} pps\n--- Rotation Rate  : {scanrate} Hz\n--- Save Raw Data  : {saveRaw}\n--- Other Metadata : {other}{CLI.COLORS.ENDC}")
                             else:
-                                print(f"{CLI.COLORS.HEADER}Obtained:\n--- Wavelength     : {wavelength} nm\n--- Precision      : {precision} pps\n--- Other Metadata : {other}{CLI.COLORS.ENDC}")
+                                print(f"{CLI.COLORS.HEADER}Obtained:\n--- Wavelength     : {wavelength} nm\n--- Precision      : {precision} pps\n--- Save Raw Data  : {saveRaw}\n--- Other Metadata : {other}{CLI.COLORS.ENDC}")
 
                             confirm = CLI.whats_it_gonna_be_boy(f"Proceed?", default = "yes")
 
@@ -195,7 +197,7 @@ with cam(devMode = devMode) as n:
                             n.rotationFrequency = scanrate
                             meta["NanoScan Rotation Rate (Hz)"] = scanrate
 
-                        M.take_measurements(precision = precision, metadata = meta, removeOutliers = removeOutliers, threshold = threshold) 
+                        M.take_measurements(precision = precision, metadata = meta, removeOutliers = removeOutliers, threshold = threshold, saveRaw = saveRaw) 
                         
                         print(f"{CLI.COLORS.OKGREEN}Done!{CLI.COLORS.ENDC}")
 

--- a/src/nanosquared/cameras/camera.py
+++ b/src/nanosquared/cameras/camera.py
@@ -18,7 +18,7 @@ class Camera(h.LoggerMixIn):
     def __init__(self):
         self.apertureOpen = False
 
-    def getAxis_avg_D4Sigma(self, axis: CameraAxes, numsamples: int = 20, *args, **kwargs):
+    def getAxis_avg_D4Sigma(self, axis: CameraAxes, numsamples: int = 20, returnRaw: bool = False, *args, **kwargs):
         raise NotImplementedError
 
     def wait_stable(self):

--- a/src/nanosquared/cameras/nanoscan.py
+++ b/src/nanosquared/cameras/nanoscan.py
@@ -137,7 +137,7 @@ class NanoScan(cam.Camera):
 
 		return arr_rem
 
-	def getAxis_avg_D4Sigma(self, axis: NsAxes, numsamples: int = 20, removeOutliers: int = 0, threshold: float = 0.2, *args, **kwargs) -> Tuple[float, float]:
+	def getAxis_avg_D4Sigma(self, axis: NsAxes, numsamples: int = 20, removeOutliers: int = 0, threshold: float = 0.2, returnRaw: bool = False, *args, **kwargs) -> Tuple[float, float]:
 		"""Get the d4sigma in one `axis` and averages it over `numsamples` using the Sync1Rev implementation.
 
 		Using NsAxes somewhat changes the signature of this function in a strict sense, but at this point I think would make easier for me to check.
@@ -214,6 +214,9 @@ class NanoScan(cam.Camera):
 		# Throwaway the first 10 values
 		out = out[10:]
 
+		if returnRaw:
+			rawout = out
+
 		# Remove Outliers
 		if removeOutliers == 1:
 			# Throw away top 10% of values
@@ -253,6 +256,9 @@ class NanoScan(cam.Camera):
 			ret = (average.flatten()[axis], stddev.flatten()[axis])
 
 		self.NS.SelectParameters(originalParams)
+
+		if returnRaw:
+			return ret, rawout
 
 		return ret
 		

--- a/src/nanosquared/cameras/nanoscan.py
+++ b/src/nanosquared/cameras/nanoscan.py
@@ -170,6 +170,12 @@ class NanoScan(cam.Camera):
 			If an invalid value is given, then threshold = 0.2
 
 			By default 0.2 = 20% of the average.
+		returnRaw: bool, optional
+			Whether to return the raw data obtained as well. 
+
+			If set to True, the function returns the tuple (result, rawdata)
+
+			By default, False
 
 		Returns
 		-------

--- a/src/nanosquared/cameras/wincamd.py
+++ b/src/nanosquared/cameras/wincamd.py
@@ -168,7 +168,7 @@ class WinCamD(cam.Camera):
 		return self.dataCtrl.dynamicCall(f"SetClipLevel({clip}, 0.5, {mode}, {CLIP_MODES.CLIP_LEVEL_METHOD})")
 
 	# Implementations
-	def getAxis_avg_D4Sigma(self, axis: WinCamAxes, numsamples: int = 20, *args, **kwargs) -> Tuple[float, float]:
+	def getAxis_avg_D4Sigma(self, axis: WinCamAxes, numsamples: int = 20, returnRaw: bool = False, *args, **kwargs) -> Tuple[float, float]:
 		"""Get the d4sigma in one `axis` and averages it over `numsamples`.
 		This function opens the camera where necessary, and returns it to the previous state after it is done.
 
@@ -182,6 +182,8 @@ class WinCamD(cam.Camera):
 			May take values 'x' or 'y'
 		numsamples : int, optional
 			Number of samples to average over, by default 20
+		returnRaw : bool, optional
+			If set to True, return the raw data
 
 		Returns
 		-------
@@ -222,9 +224,15 @@ class WinCamD(cam.Camera):
 		if axis == self.AXES.BOTH:
 			average = np.average(data, axis = 0)
 			stddev  = np.std(data, axis = 0)
-			return np.vstack((average, stddev)).T
+			
+			ret = np.vstack((average, stddev)).T
 		else:
-			return (np.average(data), np.std(data))
+			ret = (np.average(data), np.std(data))
+
+		if returnRaw:
+			return ret, data
+		else:
+			return ret
 
 	def getAxis_D4Sigma(self, axis: WinCamAxes):
 		"""Get the d4sigma in one `axis`, opens the camera if necessary, then restores the previous state that the camera was in.

--- a/src/nanosquared/measurement/measure.py
+++ b/src/nanosquared/measurement/measure.py
@@ -124,7 +124,7 @@ class Measurement(h.LoggerMixIn):
             try:
                 self.openedFile.close()
                 self.openedFile = None
-            except (OSError, IOError) as e:
+            except OSError as e:
                 pass
 
     def __enter__(self):

--- a/src/nanosquared/measurement/measure.py
+++ b/src/nanosquared/measurement/measure.py
@@ -183,7 +183,7 @@ class Measurement(h.LoggerMixIn):
 
         if rayleighLength is None:
             try:
-                rayleighLength = np.array(self.find_zR_pps(center = _center, axis = axis, precision = precision))
+                rayleighLength = np.array(self.find_zR_pps(center = _center, axis = axis, precision = precision, saveRaw = saveRaw))
             except me.StageOutOfRangeError as e:
                 raise me.ConfigurationError(f"The travel range of the stage does not support the current configuration")
         else:
@@ -644,7 +644,7 @@ class Measurement(h.LoggerMixIn):
         self.log(f"Center at {cen}")
         return cen
 
-    def find_zR_pps(self, center: int, axis: Camera.AXES, precision: int = 10, other: int = None, kappa1: float = 0, kappa2: float = scipy.constants.golden) -> Union[int, Tuple[int, int]]:
+    def find_zR_pps(self, center: int, axis: Camera.AXES, precision: int = 10, other: int = None, kappa1: float = 0, kappa2: float = scipy.constants.golden, saveRaw: Optional[TextIO] = None) -> Union[int, Tuple[int, int]]:
         """Using the center, automatically finds the approximate Rayleigh Length
 
         IMPORTANT: Assumes that find_center has been run, or that somehow the stage is homed properly
@@ -694,13 +694,13 @@ class Measurement(h.LoggerMixIn):
             #     ])
             omega_0 = None
         else:
-            omega_0 = np.array(self.measure_at(axis = axis, pos = center))
+            omega_0 = np.array(self.measure_at(axis = axis, pos = center, saveRaw = saveRaw))
 
         if omega_0 is not None:
             sqrt2_omega = np.sqrt(2) * omega_0
 
         def evaluate(pos: int):
-            data = self.measure_at(axis = axis, pos = pos)
+            data = self.measure_at(axis = axis, pos = pos, saveRaw = saveRaw)
             return data - sqrt2_omega if BOTH else (data - sqrt2_omega)[0]
 
         # We implement the ITP Method and somehow improve it so that it keeps track of the other axis as well

--- a/src/nanosquared/measurement/measure.py
+++ b/src/nanosquared/measurement/measure.py
@@ -269,6 +269,12 @@ class Measurement(h.LoggerMixIn):
 
         if isinstance(saveRaw, TextIOWrapper):
             metadata["Raw Data File"] = os.path.realpath(saveRaw.name)
+        
+        if isinstance(self.camera, NanoScan):
+            postProcMethod = ["0: Do Nothing", "1: Remove top 10%", "2: Remove positive peaks from data"]
+            metadata["Post Processing Mode"] = postProcMethod[removeOutliers]
+            if removeOutliers == 2:
+                metadata["Threshold"] = threshold
 
         self.write_to_file(writeToFile = writeToFile, metadata = metadata)
 

--- a/src/nanosquared/measurement/measure.py
+++ b/src/nanosquared/measurement/measure.py
@@ -90,11 +90,17 @@ class Measurement(h.LoggerMixIn):
         self.removeOutliers = 0
         self.threshold      = 0.2     
 
+        self.openedFile = None
+
     def __enter__(self):
         return self
 
     def __exit__(self, e_type, e_val, traceback):
-        pass
+        if isinstance(self.openedFile, TextIOWrapper):
+            try:
+                self.openedFile.close()
+            except (OSError, IOError) as e:
+                pass
 
     def take_measurements(self, axis: Camera.AXES = None, center: int = None, rayleighLength: float = None, precision: int = 100, numsamples: int = 50, writeToFile: Optional[str] = None, metadata: dict = dict(), removeOutliers: int = 0, threshold: float = 0.2, saveRaw: bool = False):
         """Function that takes the necessary measurements for M^2, automatically selects the range based
@@ -169,6 +175,7 @@ class Measurement(h.LoggerMixIn):
 
         if saveRaw:
             saveRaw = self.get_raw_file(metadata = metadata)
+            self.openedFile = saveRaw
             
         # initialization
         self.data = { self.camera.AXES.X : None, self.camera.AXES.Y : None }
@@ -260,6 +267,7 @@ class Measurement(h.LoggerMixIn):
 
         if isinstance(saveRaw, TextIOWrapper):
             saveRaw.close()
+            self.openedFile = None
 
         default_meta = {
             "Rayleigh Length": f"{self.controller.pulse_to_um(pps = rayleighLength) / 1000} mm"

--- a/src/nanosquared/measurement/measure.py
+++ b/src/nanosquared/measurement/measure.py
@@ -123,6 +123,7 @@ class Measurement(h.LoggerMixIn):
         if isinstance(self.openedFile, TextIOWrapper):
             try:
                 self.openedFile.close()
+                self.openedFile = None
             except (OSError, IOError) as e:
                 pass
 

--- a/src/nanosquared/measurement/measure.py
+++ b/src/nanosquared/measurement/measure.py
@@ -334,7 +334,7 @@ class Measurement(h.LoggerMixIn):
         elif pfad is None:
             # We create a file in the M2 directory to save the data.
 
-            tempdir = os.path.join(root_dir, ".." ,"data", "M2")
+            tempdir = os.path.join(root_dir, ".." ,"nanosquared-data", "M2")
             Path(tempdir).mkdir(parents=True, exist_ok=True)
             fd, pfad = tempfile.mkstemp(suffix = ".raw.log" if not self.devMode else ".dev.raw.log", prefix = now.strftime("%Y-%m-%d_%H%M%S_"), dir = tempdir, text = True)
             # Returns a file descriptor instead of the file
@@ -395,7 +395,7 @@ class Measurement(h.LoggerMixIn):
         elif pfad is None:
             # We create a file in the M2 directory to save the data.
 
-            tempdir = os.path.join(root_dir, ".." ,"data", "M2")
+            tempdir = os.path.join(root_dir, ".." ,"nanosquared-data", "M2")
             Path(tempdir).mkdir(parents=True, exist_ok=True)
             fd, pfad = tempfile.mkstemp(suffix = ".dat" if not self.devMode else ".dev.dat", prefix = now.strftime("%Y-%m-%d_%H%M%S_"), dir = tempdir, text = True)
             # Returns a file descriptor instead of the file

--- a/src/nanosquared/measurement/measure.py
+++ b/src/nanosquared/measurement/measure.py
@@ -177,7 +177,7 @@ class Measurement(h.LoggerMixIn):
         # TODO: CHECK IF CENTER IS CORRECT FOR AXIS CHOSEN
         # TODO: Check if rayleigh length is correct size for axis chosen
         if isinstance(saveRaw, TextIOWrapper):
-            saveRaw.write("=== Finding Center ===\n")
+            saveRaw.write("# === Finding Center ===\n")
 
         if axis == self.camera.AXES.BOTH:
             _center    = self.find_center_xy(precision = precision, saveRaw = saveRaw)          if center is None else center
@@ -187,7 +187,7 @@ class Measurement(h.LoggerMixIn):
         if rayleighLength is None:
             try:
                 if isinstance(saveRaw, TextIOWrapper):
-                    saveRaw.write("=== Finding Rayleigh Length ===\n")
+                    saveRaw.write("# === Finding Rayleigh Length ===\n")
                 rayleighLength = np.array(self.find_zR_pps(center = _center, axis = axis, precision = precision, saveRaw = saveRaw))
             except me.StageOutOfRangeError as e:
                 raise me.ConfigurationError(f"The travel range of the stage does not support the current configuration")

--- a/src/nanosquared/measurement/measure.py
+++ b/src/nanosquared/measurement/measure.py
@@ -267,6 +267,9 @@ class Measurement(h.LoggerMixIn):
 
         metadata = {**default_meta, **metadata}
 
+        if isinstance(saveRaw, TextIOWrapper):
+            metadata["Raw Data File"] = os.path.realpath(saveRaw.name)
+
         self.write_to_file(writeToFile = writeToFile, metadata = metadata)
 
         return self.data

--- a/src/nanosquared/stage/controller.py
+++ b/src/nanosquared/stage/controller.py
@@ -117,7 +117,7 @@ class Controller(abc.ABC, h.LoggerMixIn):
         """
 
         print("^C Detected: Emergency stop and closing port.")
-        print("Shutter will be closed as part of the aborting process.")
+        # print("Shutter will be closed as part of the aborting process.")
         self.abort()
         self.closeDevice()
         print("Exiting")

--- a/src/nanosquared/stage/controller.py
+++ b/src/nanosquared/stage/controller.py
@@ -120,8 +120,10 @@ class Controller(abc.ABC, h.LoggerMixIn):
         # print("Shutter will be closed as part of the aborting process.")
         self.abort()
         self.closeDevice()
-        print("Exiting")
-        sys.exit(1)
+        raise KeyboardInterrupt
+        
+        # print("Exiting")
+        # sys.exit(1)
         # use os._exit(1) to avoid raising any SystemExit exception
 
 class SerialController(Controller, abc.ABC):

--- a/tests/test_sigint.py
+++ b/tests/test_sigint.py
@@ -1,0 +1,28 @@
+import signal
+from time import sleep
+
+# https://stackoverflow.com/a/4205386/3211506
+
+def _handler(sig, frame):
+    print(f"Handling {sig}")
+    raise KeyboardInterrupt
+
+signals = [signal.SIGINT, signal.SIGABRT, signal.SIGFPE, signal.SIGILL, signal.SIGSEGV, signal.SIGTERM]
+
+for i in signals:
+    signal.signal(i, _handler)
+
+class A():
+    def __init__(self) -> None:
+        pass
+
+    def __enter__(self):
+        return self
+    
+    def __exit__(self, e_type, e_val, traceback):
+        print("Exit")
+        return
+    
+with A() as a:
+    sleep(1)
+    raise IOError


### PR DESCRIPTION
Using the `saveRaw` parameter, you can now save the raw data from the beam profiler before any averaging happens. 